### PR TITLE
[Fix] Remove error go path cleanup

### DIFF
--- a/pkg/logs/errorstackmarshaler.go
+++ b/pkg/logs/errorstackmarshaler.go
@@ -1,7 +1,6 @@
 package logs
 
 import (
-	"regexp"
 	"runtime"
 	"strings"
 
@@ -38,14 +37,6 @@ func isGoSource(source string) bool {
 	return strings.HasPrefix(source, goroot)
 }
 
-var (
-	goPathRegex  = regexp.MustCompile("/go/(pkg/mod/)?")
-	removeGoPath = func(source string) string {
-		sourceParts := goPathRegex.Split(source, 2)
-		return sourceParts[len(sourceParts)-1]
-	}
-)
-
 func getErrorFrames(err error) *stackTrace {
 	if err == nil {
 		return nil
@@ -71,7 +62,7 @@ func getErrorFrames(err error) *stackTrace {
 
 		funcName := fn.Name()
 		result.Frames = append(result.Frames, frame{
-			Source: removeGoPath(file),
+			Source: file,
 			Line:   line,
 			Func:   removePackageName(funcName),
 		})

--- a/pkg/logs/logger.go
+++ b/pkg/logs/logger.go
@@ -25,7 +25,6 @@ func init() {
 		Logger = log.Logger
 	} else {
 		// will probably only use a console decorator during development
-		removeGoPath = func(source string) string { return source }
 		Logger = log.Logger.Output(zerolog.NewConsoleWriter(
 			func(w *zerolog.ConsoleWriter) {
 				w.TimeFormat = time.RFC3339


### PR DESCRIPTION
Remove error go path cleanup in favor of `-trimpath` [go build flag](https://pkg.go.dev/cmd/go#:~:text=but%20still%20recognized.\)-,%2Dtrimpath,-remove%20all%20file)